### PR TITLE
Added __init__.py.

### DIFF
--- a/pyrcb.py
+++ b/pyrcb.py
@@ -167,3 +167,4 @@ class IrcBot(object):
         self._buffer = ""
         self.is_registered = False
         self.channels = []
+ 

--- a/pyrcb.py
+++ b/pyrcb.py
@@ -167,4 +167,4 @@ class IrcBot(object):
         self._buffer = ""
         self.is_registered = False
         self.channels = []
- 
+


### PR DESCRIPTION
This allows users to keep pyrcb in a separate folder and import it (`from pyrcb import pyrcb` or `import pyrcb.pyrcb`).
